### PR TITLE
update targetframework to netstandard2.0

### DIFF
--- a/Kveer.XmlRPC/Kveer.XmlRPC.csproj
+++ b/Kveer.XmlRPC/Kveer.XmlRPC.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>CookComputing.XmlRpc</RootNamespace>
     <Authors>Sébastien Rault</Authors>
     <Company>Kveer</Company>
@@ -9,7 +9,7 @@
     <Copyright>Sébastien Rault</Copyright>
     <SignAssembly>false</SignAssembly>
     <PackageTags>xmlrpc</PackageTags>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageReleaseNotes>- publish the symbols on https://nuget.smbsrc.net
 - fully automate the build</PackageReleaseNotes>

--- a/Kveer.XmlRPC/XmlRpcProxyGen.cs
+++ b/Kveer.XmlRPC/XmlRpcProxyGen.cs
@@ -105,7 +105,7 @@ namespace CookComputing.XmlRpc
 			BuildMethods(typeBldr, methods);
 			BuildBeginMethods(typeBldr, beginMethods);
 			BuildEndMethods(typeBldr, endMethods);
-			typeBldr.CreateType();
+			typeBldr.CreateTypeInfo();
 			return assBldr;
 		}
 


### PR DESCRIPTION
I think this lib should be targeting to netstandard2.0,
so all of projects targeting .Net Framework 4.6.1 or netcoreapp can use this lib.