### PR TITLE
fix Fault struct casing to align to xml response

### DIFF
--- a/Kveer.XmlRPC/XmlRpcSerializer.cs
+++ b/Kveer.XmlRPC/XmlRpcSerializer.cs
@@ -39,8 +39,8 @@ namespace CookComputing.XmlRpc
 {
 	internal struct Fault
 	{
-		public int FaultCode;
-		public string FaultString;
+		public int faultCode;
+		public string faultString;
 	}
 
 	public class XmlRpcSerializer
@@ -1488,8 +1488,8 @@ namespace CookComputing.XmlRpc
 				{
 					faultStrCode = (FaultStructStringCode)ParseValue(structNode,
 																	  typeof(FaultStructStringCode), parseStack, mappingAction);
-					fault.FaultCode = Convert.ToInt32(faultStrCode.FaultCode);
-					fault.FaultString = faultStrCode.FaultString;
+					fault.faultCode = Convert.ToInt32(faultStrCode.FaultCode);
+					fault.faultString = faultStrCode.FaultString;
 				}
 				catch (Exception)
 				{
@@ -1498,7 +1498,7 @@ namespace CookComputing.XmlRpc
 				}
 			}
 
-			return new XmlRpcFaultException(fault.FaultCode, fault.FaultString);
+			return new XmlRpcFaultException(fault.faultCode, fault.faultString);
 		}
 
 		public void SerializeFaultResponse(


### PR DESCRIPTION
Fault struct didn't conform to xml fault response. Also deviated from original
 implementation at cook computing. 

![screen shot 2018-11-27 at 13 33 38](https://user-images.githubusercontent.com/4512250/49106572-214c8f00-f249-11e8-9dde-ac8b3a55eed1.png)


