### PR TITLE
Add support for null parameter serialization and related tests

### DIFF
--- a/Kveer.XmlRPC.Tests/serializetest.cs
+++ b/Kveer.XmlRPC.Tests/serializetest.cs
@@ -1303,5 +1303,47 @@ namespace Kveer.XmlRPC.Tests
 			Assert.IsTrue(xmlRpcStruct["ms"] is string);
 			Assert.AreEqual((string) xmlRpcStruct["ms"], "another test string");
 		}
+		        //---------------------- null parameter with flag --------------------------// 
+        [Test]
+        public void NullParameter_WithAllowNullParams()
+        {
+            Stream stm = new MemoryStream();
+            var req = new XmlRpcRequest();
+            req.args = new object[] { null };
+            req.method = "Foo";
+
+            var ser = new XmlRpcSerializer();
+            ser.NonStandard = XmlRpcNonStandard.AllowNullParams; 
+
+            ser.SerializeRequest(stm, req);
+            stm.Position = 0;
+            TextReader tr = new StreamReader(stm);
+            var reqstr = tr.ReadToEnd();
+
+            Assert.AreEqual(
+                @"<?xml version=""1.0""?>
+<methodCall>
+  <methodName>Foo</methodName>
+  <params>
+    <param>
+      <value>
+        <nil />
+      </value>
+    </param>
+  </params>
+</methodCall>".Replace("\r\n", Environment.NewLine), reqstr);
+        }
+        [Test]
+        public void NullParam_ThrowsWithoutFlag()
+        {
+            Stream stm = new MemoryStream();
+            var req = new XmlRpcRequest();
+            req.args = new object[] { null };
+            req.method = "Foo";
+
+            var ser = new XmlRpcSerializer();
+
+            Assert.That(() => ser.SerializeRequest(stm, req), Throws.TypeOf<XmlRpcNullParameterException>());
+        }
 	}
 }

--- a/Kveer.XmlRPC/XmlRpcNonStandard.cs
+++ b/Kveer.XmlRPC/XmlRpcNonStandard.cs
@@ -37,6 +37,7 @@ namespace CookComputing.XmlRpc
 		MapZerosDateTimeToMinValue = 0x8,
 		MapEmptyDateTimeToMinValue = 0x10,
 		AllowInvalidHttpContent    = 0x20,
+		AllowNullParams			   = 0x40,
 		All                        = 0x7fff
 	}
 }

--- a/Kveer.XmlRPC/XmlRpcSerializer.cs
+++ b/Kveer.XmlRPC/XmlRpcSerializer.cs
@@ -125,29 +125,55 @@ namespace CookComputing.XmlRpc
 						&& Attribute.IsDefined(pis[i], typeof(ParamArrayAttribute)))
 					{
 						var ary = (Array)request.args[i];
-						foreach (var o in ary)
-						{
-							if (o == null)
-								throw new XmlRpcNullParameterException(
-									"Null parameter in params array");
-							xtw.WriteStartElement("", "param", "");
-							Serialize(xtw, o, mappingAction);
-							xtw.WriteEndElement();
-						}
+						                foreach (var o in ary)
+                {
+                    xtw.WriteStartElement("", "param", "");
+                    if (o == null)
+                    {
+                        if ((NonStandard & XmlRpcNonStandard.AllowNullParams) != 0)
+                        {
+                            xtw.WriteStartElement("", "value", "");
+                            xtw.WriteStartElement("", "nil", "");
+                            xtw.WriteEndElement(); 
+                            xtw.WriteEndElement(); 
+                        }
+                        else
+                        {
+                            throw new XmlRpcNullParameterException("Null parameter in params array");
+                        }
+                    }
+                    else
+                    {
+                        Serialize(xtw, o, mappingAction);
+                    }
+                    xtw.WriteEndElement(); 
+                }
+                break;
+            }
+        }
 
-						break;
-					}
-				}
-
-				if (request.args[i] == null)
-					throw new XmlRpcNullParameterException(string.Format(
-															   "Null method parameter #{0}", i + 1));
-				xtw.WriteStartElement("", "param", "");
-				Serialize(xtw, request.args[i], mappingAction);
-				xtw.WriteEndElement();
-			}
-		}
-
+        xtw.WriteStartElement("", "param", "");
+        if (request.args[i] == null)
+        {
+            if ((NonStandard & XmlRpcNonStandard.AllowNullParams) != 0)
+            {
+                xtw.WriteStartElement("", "value", "");
+                xtw.WriteStartElement("", "nil", "");
+                xtw.WriteEndElement(); 
+                xtw.WriteEndElement(); 
+            }
+            else
+            {
+                throw new XmlRpcNullParameterException($"Null method parameter #{i + 1}");
+            }
+        }
+        else
+        {
+            Serialize(xtw, request.args[i], mappingAction);
+        }
+        xtw.WriteEndElement();
+    }
+}
 		private void SerializeStructParams(XmlTextWriter xtw, XmlRpcRequest request,
 										   MappingAction mappingAction)
 		{
@@ -164,12 +190,27 @@ namespace CookComputing.XmlRpc
 			xtw.WriteStartElement("", "struct", "");
 			for (var i = 0; i < request.args.Length; i++)
 			{
-				if (request.args[i] == null)
-					throw new XmlRpcNullParameterException(string.Format(
-															   "Null method parameter #{0}", i + 1));
+			
 				xtw.WriteStartElement("", "member", "");
 				xtw.WriteElementString("name", pis[i].Name);
-				Serialize(xtw, request.args[i], mappingAction);
+				                if (request.args[i] == null)
+                {
+                    if ((NonStandard & XmlRpcNonStandard.AllowNullParams) != 0)
+                    {
+                        xtw.WriteStartElement("", "value", "");
+                        xtw.WriteStartElement("", "nil", "");
+                        xtw.WriteEndElement(); 
+                        xtw.WriteEndElement();
+                    }
+                    else
+                    {
+                        throw new XmlRpcNullParameterException($"Null method parameter #{i + 1}");
+                    }
+                }
+                else
+                {
+                    Serialize(xtw, request.args[i], mappingAction);
+                }
 				xtw.WriteEndElement();
 			}
 


### PR DESCRIPTION
 Introduced XmlRpcNonStandard.AllowNullParams flag
Updated serializer to support null parameters
Added unit tests to cover behavior with and without the flag
