### PR TITLE
leave stream open after the reader is disposed

### DIFF
--- a/Kveer.XmlRPC/Kveer.XmlRPC.csproj
+++ b/Kveer.XmlRPC/Kveer.XmlRPC.csproj
@@ -1,35 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <RootNamespace>CookComputing.XmlRpc</RootNamespace>
-    <Authors>Sébastien Rault</Authors>
-    <Company>Kveer</Company>
-    <Description>A port of CookComputing.XmlRpcV2 for dotnet core.</Description>
-    <Copyright>Sébastien Rault</Copyright>
-    <PackageTags>xmlrpc</PackageTags>
-    <Version>1.3.1</Version>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageReleaseNotes>- add support for &lt;long&gt; nodes
-- update targetframework to a supported version</PackageReleaseNotes>
-    <PackageLicense>MIT License</PackageLicense>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <PackageProjectUrl>https://github.com/LordVeovis/xmlrpc</PackageProjectUrl>
-    <RepositoryUrl>git@github.com:LordVeovis/xmlrpc.git</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <AssemblyOriginatorKeyFile>sn-prd.pub</AssemblyOriginatorKeyFile>
-    <SignAssembly>false</SignAssembly>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(CIRCLE_TAG)' != '' ">
-    <SignAssembly>true</SignAssembly>
-    <DelaySign>true</DelaySign>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<RootNamespace>CookComputing.XmlRpc</RootNamespace>
+		<Description>A port of CookComputing.XmlRpcV2 for dotnet core.</Description>
+		<PackageId>Kveer.XmlRpc.Unsigned</PackageId>
+		<PackageTags>xmlrpc</PackageTags>
+		<Version>1.3.1</Version>
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+		<PackageReleaseNotes>Unsigned version</PackageReleaseNotes>
+		<PackageLicense>MIT License</PackageLicense>
+		<PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+		<PackageProjectUrl>https://github.com/fcsobel/xmlrpc</PackageProjectUrl>
+		<RepositoryType>git</RepositoryType>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
-    <None Include="..\README.md" Pack="true" PackagePath="\" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
+	</ItemGroup>
 
 </Project>

--- a/Kveer.XmlRPC/XmlRpcSerializer.cs
+++ b/Kveer.XmlRPC/XmlRpcSerializer.cs
@@ -207,11 +207,13 @@ namespace CookComputing.XmlRpc
 			var xdoc = new XmlDocument { PreserveWhitespace = true };
 			try
 			{
-				using (var xmlRdr = new XmlTextReader(stm))
+				var settings = new XmlReaderSettings();
+				#if (!COMPACT_FRAMEWORK)
+				settings.DtdProcessing = DtdProcessing.Prohibit;
+				#endif
+				using (var reader = new StreamReader(stm, Encoding.UTF8, true, 1024, leaveOpen: true))
+				using (var xmlRdr = XmlReader.Create(reader, settings))
 				{
-#if (!COMPACT_FRAMEWORK)
-					xmlRdr.DtdProcessing = DtdProcessing.Prohibit;
-#endif
 					xdoc.Load(xmlRdr);
 				}
 			}

--- a/Kveer.XmlRPC/XmlRpcSerializer.cs
+++ b/Kveer.XmlRPC/XmlRpcSerializer.cs
@@ -211,8 +211,7 @@ namespace CookComputing.XmlRpc
 			#endif
 			try
 			{
-				using (var reader = new StreamReader(stm, Encoding.UTF8, true, 1024, leaveOpen: true))
-				using (var xmlRdr = XmlReader.Create(reader, stng))
+				using (var xmlRdr = XmlReader.Create(stm, stng))
 				{
 					xdoc.Load(xmlRdr);
 				}

--- a/Kveer.XmlRPC/XmlRpcSerializer.cs
+++ b/Kveer.XmlRPC/XmlRpcSerializer.cs
@@ -205,13 +205,15 @@ namespace CookComputing.XmlRpc
 			}
 
 			var xdoc = new XmlDocument { PreserveWhitespace = true };
+			var stng = new XmlReaderSettings();
+			#if (!COMPACT_FRAMEWORK)
+			stng.DtdProcessing = DtdProcessing.Prohibit;
+			#endif
 			try
 			{
-				using (var xmlRdr = new XmlTextReader(stm))
+				using (var reader = new StreamReader(stm, Encoding.UTF8, true, 1024, leaveOpen: true))
+				using (var xmlRdr = XmlReader.Create(reader, stng))
 				{
-#if (!COMPACT_FRAMEWORK)
-					xmlRdr.DtdProcessing = DtdProcessing.Prohibit;
-#endif
 					xdoc.Load(xmlRdr);
 				}
 			}

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # Kveer.XmlRPC
 
-[![CircleCI](https://circleci.com/gh/LordVeovis/xmlrpc.svg?style=shield)](https://app.circleci.com/pipelines/github/LordVeovis)
-[![Codacy Badge](https://app.codacy.com/project/badge/Grade/a6cde759dac74c278c8a77cfbb4b968a)](https://app.codacy.com/gh/LordVeovis/xmlrpc/dashboard)
-[![Build Status](https://gitlab.kveer.fr/veovis/xmlrpc/badges/master/pipeline.svg)](https://gitlab.kveer.fr/veovis/xmlrpc/pipelines)
-[![Code Coverage](https://gitlab.kveer.fr/veovis/xmlrpc/badges/master/coverage.svg)](https://gitlab.kveer.fr/veovis/xmlrpc/pipelines)
-[![Nuget Downloads](https://img.shields.io/nuget/dt/Kveer.XmlRpc.svg)](https://www.nuget.org/packages/Kveer.XmlRPC/)
+Created unsigned version to resolve: 
+[Strong name signature could not be verified](https://github.com/LordVeovis/xmlrpc/issues/28)
+
+```
+Could not load file or assembly 'Kveer.XmlRPC' or one of its dependencies. 
+Strong name signature could not be verified. 
+The assembly may have been tampered with, or it was delay signed but not fully signed with the correct private key. 
+(Exception from HRESULT: 0x80131045)
+```
 
 This repository contains a .net library for consuming XML-RPC web services. It is a port of the Charles Cook's library mainly for .NET Core 2.x+ but target the netstandard 2.0, so it can also be used on the full .NET Framework 4.6.1+.
 


### PR DESCRIPTION
Change from XmlTextReader to StreamReader & XmlReader to leave the stream open 
Fix for Stream is close, exception #24 when response logging enabled 